### PR TITLE
routing 翻译

### DIFF
--- a/about.md
+++ b/about.md
@@ -169,6 +169,7 @@
 - Session (不翻)
 - Seed 数据填充
 - Scheduler 计划器
+- Scout (不翻)
 
 ### T
 

--- a/facades.md
+++ b/facades.md
@@ -1,18 +1,17 @@
 # Facades
 
-- [Introduction](#introduction)
-- [When To Use Facades](#when-to-use-facades)
-    - [Facades Vs. Dependency Injection](#facades-vs-dependency-injection)
-    - [Facades Vs. Helper Functions](#facades-vs-helper-functions)
-- [How Facades Work](#how-facades-work)
-- [Facade Class Reference](#facade-class-reference)
+- [简介](#introduction)
+- [何时使用 Facades](#when-to-use-facades)
+    - [Facades 对比依赖注入](#facades-vs-dependency-injection)
+    - [Facades 对比辅助函数](#facades-vs-helper-functions)
+- [Facades 如何工作](#how-facades-work)
+- [Facade 类参考](#facade-class-reference)
 
 <a name="introduction"></a>
-## Introduction
+## 简介
+Facades /fəˈsäd/ 为应用程序的[服务容器](/docs/{{version}}/container)中可用的类提供了一个「静态」接口。Laravel 自带了许多的 facades，可以用来访问其几乎所有的服务。Laravel facades 就是服务容器里那些基类的「静态代理」，相比于传统的静态方法调用，facades 在提供更简洁且丰富的语法的同时，还有更好的可测试性和扩展性。
 
-Facades provide a "static" interface to classes that are available in the application's [service container](/docs/{{version}}/container). Laravel ships with many facades which provide access to almost all of Laravel's features. Laravel facades serve as "static proxies" to underlying classes in the service container, providing the benefit of a terse, expressive syntax while maintaining more testability and flexibility than traditional static methods.
-
-All of Laravel's facades are defined in the `Illuminate\Support\Facades` namespace. So, we can easily access a facade like so:
+所有的 Laravel facades 都在 `Illuminate\Support\Facades` 这个命名空间下。所以我们可以用类似下面的代码轻松调用：
 
     use Illuminate\Support\Facades\Cache;
 
@@ -20,23 +19,23 @@ All of Laravel's facades are defined in the `Illuminate\Support\Facades` namespa
         return Cache::get('key');
     });
 
-Throughout the Laravel documentation, many of the examples will use facades to demonstrate various features of the framework.
+在 Laravel 的文档中，很多代码示例都使用了 facades 来演示框架的各种特性。
 
 <a name="when-to-use-facades"></a>
-## When To Use Facades
+## 何时使用 Facades
 
-Facades have many benefits. They provide a terse, memorable syntax that allows you to use Laravel's features without remembering long class names that must be injected or configured manually. Furthermore, because of their unique usage of PHP's dynamic methods, they are easy to test.
+Facades 有很多的好处，它们提供了简单易记的语法让你使用 Laravel 的各种功能，你再也不需要记住长长的类名来实现注入或者手动去配置。还有，因为它们对于PHP动态方法的独特用法，测试起来就非常容易。
 
-However, some care must be taken when using facades. The primary danger of facades is class scope creep. Since facades are so easy to use and do not require injection, it can be easy to let your classes continue to grow and use many facades in a single class. Using dependency injection, this potential is mitigated by the visual feedback a large constructor gives you that your class is growing too large. So, when using facades, pay special attention to the size of your class so that it's scope of responsibility stays narrow.
+但是，在使用 facades 时，有些地方还是需要特别注意。使用 facades 最主要的风险就是会引起类的体积的膨胀。由于 facades 使用起来非常简单而且不需要注入，我们会不经意间在单个类中大量使用。不像是使用依赖注入，用得越多，构造方法会越长，在视觉上就会引起注意，提醒你这个类有点太庞大了。所以，在使用 facades 时，要特别注意把类的体积控制在一个合理的范围。
 
-> {tip} When building a third-party package that interacts with Laravel, it's better to inject [Laravel contracts](/docs/{{version}}/contracts) instead of using facades. Since packages are built outside of Laravel itself, you will not have access to Laravel's facade testing helpers.
+> {提示} 在开发需要和 Laravel 交互的扩展包时，最好是注入 [Laravel contracts](/docs/{{version}}/contracts) 而不是使用 facades，因为扩展包不是在 Laravel 内部编译的，无法使用 Laravel 的 facades 的测试辅助函数。
 
 <a name="facades-vs-dependency-injection"></a>
-### Facades Vs. Dependency Injection
+### Facades 对比依赖注入
 
-One of the primary benefits of dependency injection is the ability to swap implementations of the injected class. This is useful during testing since you can inject a mock or stub and assert that various methods were called on the stub.
+依赖注入一个主要的好处就是可以切换注入的类的具体实现。这在测试时很有用，因为你可以注入一个 mock 或者 stub 方法并且断言一些方法在 stub 中被调用。
 
-Typically, it would not be possible to mock or stub a truly static class method. However, since facades use dynamic methods to proxy method calls to objects resolved from the service container, we actually can test facades just as we would test an injected class instance. For example, given the following route:
+在以前，静态方法是不可能被 mock 或者 stub 的。但是因为 facades 调用的是对象的动态方法，我可以像测试注入类的实例一样测试 facades。举个例子，有这样的一个路由：
 
     use Illuminate\Support\Facades\Cache;
 
@@ -44,7 +43,7 @@ Typically, it would not be possible to mock or stub a truly static class method.
         return Cache::get('key');
     });
 
-We can write the following test to verify that the `Cache::get` method was called with the argument we expected:
+我们可以用下面的测试代码去验证 `Cache::get` 方法是否像我们预期那样被调用并传入参数。
 
     use Illuminate\Support\Facades\Cache;
 
@@ -64,21 +63,21 @@ We can write the following test to verify that the `Cache::get` method was calle
     }
 
 <a name="facades-vs-helper-functions"></a>
-### Facades Vs. Helper Functions
+### Facades 对比辅助函数
 
-In addition to facades, Laravel includes a variety of "helper" functions which can perform common tasks like generating views, firing events, dispatching jobs, or sending HTTP responses. Many of these helper functions perform the same function as a corresponding facade. For example, this facade call and helper call are equivalent:
+除了 facades，Laravel 还引入了一些「辅助函数」来实现一些常用的功能，比如生成视图，触发事件，调度任务或者发送 HTTP 响应。许多辅助函数的功能其实和对应的 facades 一样。举例来说，这个 facede 和辅助函数是一样的：
 
     return View::make('profile');
 
     return view('profile');
 
-There is absolutely no practical difference between facades and helper functions. When using helper functions, you may still test them exactly as you would the corresponding facade. For example, given the following route:
+Facade 和辅助函数其实没有本质区别，当使用辅助函数时，你依然可以像使用对应的 facade 一样测试它们。比如，下面的路由：
 
     Route::get('/cache', function () {
         return cache('key');
     });
-
-Under the hood, the `cache` helper is going to call the `get` method on the class underlying the `Cache` facade. So, even though we are using the helper function, we can write the following test to verify that the method was called with the argument we expected:
+    
+在底层，辅助函数 `cache` 会调用 `Cache` facade 的基类的 `get` 方法。因此，即使我们是在使用辅助函数，我们依然可以用下面的代码来测试方法是不是被正确的调用了：
 
     use Illuminate\Support\Facades\Cache;
 
@@ -98,11 +97,11 @@ Under the hood, the `cache` helper is going to call the `get` method on the clas
     }
 
 <a name="how-facades-work"></a>
-## How Facades Work
+## Facades 如何工作
 
-In a Laravel application, a facade is a class that provides access to an object from the container. The machinery that makes this work is in the `Facade` class. Laravel's facades, and any custom facades you create, will extend the base `Illuminate\Support\Facades\Facade` class.
+在 Laravel 应用中，一个 facade 其实就是一个提供访问容器中对象功能的类。其中最核心的部件就是 `Facade` 类。不管是 Laravel 自带的，还是用户自定义的 Facades，都是继承了 `Illuminate\Support\Facades\Facade` 这个类。
 
-The `Facade` base class makes use of the `__callStatic()` magic-method to defer calls from your facade to an object resolved from the container. In the example below, a call is made to the Laravel cache system. By glancing at this code, one might assume that the static method `get` is being called on the `Cache` class:
+`Facade` 类利用了 `__callStatic()` 这个魔术方法来延迟调用容器中的对象的方法。在下面的例子里，调用了 Laravel 缓存系统。在代码里，我们可能以为 `Cache` 这个类的静态方法 `get` 被调用了：
 
     <?php
 
@@ -127,9 +126,9 @@ The `Facade` base class makes use of the `__callStatic()` magic-method to defer 
         }
     }
 
-Notice that near the top of the file we are "importing" the `Cache` facade. This facade serves as a proxy to accessing the underlying implementation of the `Illuminate\Contracts\Cache\Factory` interface. Any calls we make using the facade will be passed to the underlying instance of Laravel's cache service.
+注意在代码的最上面，我们导入的是 `Cache` facade。这个 facade 其实是我们获取底层 `Illuminate\Contracts\Cache\Factory` 接口实现的一个代理。我们通过这个 facade 调用的任何方法，都会被传递到 Laravel 缓存服务的底层实例中。
 
-If we look at that `Illuminate\Support\Facades\Cache` class, you'll see that there is no static method `get`:
+如果我们看一下 `Illuminate\Support\Facades\Cache` 这个类，你会发现根本没有 `get` 这个静态方法：
 
     class Cache extends Facade
     {
@@ -141,16 +140,16 @@ If we look at that `Illuminate\Support\Facades\Cache` class, you'll see that the
         protected static function getFacadeAccessor() { return 'cache'; }
     }
 
-Instead, the `Cache` facade extends the base `Facade` class and defines the method `getFacadeAccessor()`. This method's job is to return the name of a service container binding. When a user references any static method on the `Cache` facade, Laravel resolves the `cache` binding from the [service container](/docs/{{version}}/container) and runs the requested method (in this case, `get`) against that object.
+其实，`Cache` facade 是继承了基类 `Facade` 并且定义了 `getFacadeAccessor()` 方法。这个方法的功能是返回服务容器中绑定的名字。当用户调用 `Cache` facade 的静态方法时，Laravel 会解析到 `cache` 在服务容积里绑定的具体的那个实例对象，并且调用这个对象的相应方法（在这个例子里就是 `get` 方法）。
 
 <a name="facade-class-reference"></a>
-## Facade Class Reference
+## Facade 类参考
 
-Below you will find every facade and its underlying class. This is a useful tool for quickly digging into the API documentation for a given facade root. The [service container binding](/docs/{{version}}/container) key is also included where applicable.
+在下方你可以找到每个 facade 及其底层的类。这个工具对于通过指定 facade 的来源快速寻找 API 文档相当有用。可应用的[服务容器绑定](/docs/{{version}}/container)关键字也包含在里面。
 
 Facade  |  Class  |  Service Container Binding
 ------------- | ------------- | -------------
-App  |  [Illuminate\Foundation\Application](http://laravel.com/api/{{version}}/Illuminate/Foundation/Application.html)  | `app`
+App  |  [Illuminate\Foundation\Application](http://laravel.com/api/{{version}}/Illuminate/Foundationon/Application.html)  | `app`
 Artisan  |  [Illuminate\Contracts\Console\Kernel](http://laravel.com/api/{{version}}/Illuminate/Contracts/Console/Kernel.html)  |  `artisan`
 Auth  |  [Illuminate\Auth\AuthManager](http://laravel.com/api/{{version}}/Illuminate/Auth/AuthManager.html)  |  `auth`
 Blade  |  [Illuminate\View\Compilers\BladeCompiler](http://laravel.com/api/{{version}}/Illuminate/View/Compilers/BladeCompiler.html)  |  `blade.compiler`

--- a/installation.md
+++ b/installation.md
@@ -16,7 +16,7 @@ Laravel 框架会有一些系统上的要求。当然，这些要求在 [Laravel
 系统要求为以下：
 
 <div class="content-list" markdown="1">
-- PHP >= 5.5.9
+- PHP >= 5.6.4
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension


### PR DESCRIPTION
# HTTP 路由

- [基本路由](#basic-routing)
- [路由参数](#route-parameters)
    - [必选路由参数](#required-parameters)
    - [可选路由参数](#parameters-optional-parameters)
- [命名路由](#named-routes)
- [路由群组](#route-groups)
    - [中间件](#route-group-middleware)
    - [命名空间](#route-group-namespaces)
    - [子域名路由](#route-group-sub-domain-routing)
    - [路由前缀](#route-group-prefixes)
- [路由模型绑定](#route-model-binding)
    - [隐式绑定](#implicit-binding)
    - [显式绑定](#explicit-binding)
- [跨站请求伪造](#form-method-spoofing)
- [获取当前路由信息](#accessing-the-current-route)

<a name="basic-routing"></a>
## 基本路由

最基本的路由仅仅接受一个 URI 和一个 `闭包`，这里提供了一个非常简单优雅的定义路由的方法：

    Route::get('foo', function () {
        return 'Hello World';
    });

#### 默认路由文件

所有的Laravel路由定义都在 `routes` 目录。路由文件是框架自动加载的。 `routes/web.php` 文件定义了所有的web界面的路由。这些路由分配 给`web` 中间件，而这个中间件为 `Session` 和 `CSRF` 提供了保护功能。 `routes/api.php` 中的路由是没有状态的，它分配给了 `api` 中间件。

大多数的应用，都是从 `routes/web.php` 文件开始定义路由。

#### 正确的定义路由方法

我们可以注册路由来响应所有的 HTTP 请求

    Route::get($uri, $callback);
    Route::post($uri, $callback);
    Route::put($uri, $callback);
    Route::patch($uri, $callback);
    Route::delete($uri, $callback);
    Route::options($uri, $callback);

有的时候你可能需要注册一个可响应多个 HTTP 动作的路由，这时可以使用 `match` 方法，也可以使用 `any` 方法注册一个实现响应所有 HTTP 的请求的路由：

    Route::match(['get', 'post'], '/', function () {
        //
    });

    Route::any('foo', function () {
        //
    });

#### CSRF 保护

任何包含 `POST`, `PUT` 或 `DELETE` 使用 HTML 提交的路由，都在 `web` 路由中包含一个 CSRF 令牌，如果没有，这个请求将会被拒绝。更多的关于 CSRF 的说明在 [CSRF documentation](/docs/{{version}}/csrf):

    <form method="POST" action="/profile">
        {{ csrf_field() }}
        ...
    </form>

<a name="route-parameters"></a>
## 路由参数

<a name="required-parameters"></a>
### 必选路由参数

当然，有时我们需要在路由中捕获一些  URL 片段。例如，我们需要从 URL 中捕获 用户的 ID ，我们可以这样定义路由参数：

    Route::get('user/{id}', function ($id) {
        return 'User '.$id;
    });

也可以在路由中定义多个参数:

    Route::get('posts/{post}/comments/{comment}', function ($postId, $commentId) {
        //
    });


路由的参数通常都会被放在「大括号」内。当运行路由时，参数会通过路由闭包来传递。 

> **注意：** 路由参数不能包含 `-` 字符。请用下划线 (`_`) 替换。

<a name="parameters-optional-parameters"></a>
### 可选路由参数

当需要指定一个路由参数时，可以在参数后面加上 `?` 来实现，但是相应的变量必须有默认值：

    Route::get('user/{name?}', function ($name = null) {
        return $name;
    });

    Route::get('user/{name?}', function ($name = 'John') {
        return $name;
    });

<a name="named-routes"></a>
## 命名路由

命名路由可以方便的生成 URLs 或者重定向，可以在定义路由后使用 `name` 方法实现：

    Route::get('user/profile', function () {
        //
    })->name('profile');

还可以为控制器动作指定路由名称:

    Route::get('user/profile', 'UserController@showProfile')->name('profile');

#### 为命名路由生成 URLs

为路由指定了名称后，在生成 URLs 或者重定向时，可以使用全局方法 `route` 来实现：  

    // Generating URLs...
    $url = route('profile');

    // Generating Redirects...
    return redirect()->route('profile');

如果是有定义参数的命名路由，可以把参数放到 `route` 方法的第二个参数位置，参数会自动插入到 URL 中：

    Route::get('user/{id}/profile', function ($id) {
        //
    })->name('profile');

    $url = route('profile', ['id' => 1]);

<a name="route-groups"></a>
## 路由群组


路由群组允许共享路由属性，例如中间件和命名空间等，我们没有必要为每个路由单独设置共同属性，共享属性会以数组的形式放到 `Route::group` 方法的第一个参数中。

<a name="route-group-middleware"></a>
### 中间件

要给路由群组中给所有定义的路由分配中间件，可以在路由群组中使用 `middleware` 键，中间件将会依照列表内指定的顺序运行：

    Route::group(['middleware' => 'auth'], function () {
        Route::get('/', function ()    {
            // Uses Auth Middleware
        });

        Route::get('user/profile', function () {
            // Uses Auth Middleware
        });
    });

<a name="route-group-namespaces"></a>
### 命名空间

另一个常见的例子是，指定相同的 PHP 命名空间给控制器群组。可以使用 namespace 参数来指定群组内所有控制器的公共命名空间：

    Route::group(['namespace' => 'Admin'], function() {
        // Controllers Within The "App\Http\Controllers\Admin" Namespace
    });

请记住，默认 `RouteServiceProvider` 会在命名空间群组中引入你的路由文件，让你不用指定完整的 `App\Http\Controllers` 命名空间前缀就能注册控制器路由，因此，我们在定义的时候只需要指定命名空 `App\Http\Controllers` 以后的部分。

<a name="route-group-sub-domain-routing"></a>
### 子域名路由

路由群组也可以用作子域名的通配符，子域名可以像 URIs 一样当作路由群组的参数，因此允许把捕获的子域名一部分用于我们的路由或控制器。
路由群组中子域名的属性可以使用群组属性的 `domain` 键。

    Route::group(['domain' => '{account}.myapp.com'], function () {
        Route::get('user/{id}', function ($account, $id) {
            //
        });
    });

<a name="route-group-prefixes"></a>
### 路由前缀

通过路由群组数组属性中的 `prefix` 键可以给每个路由群组的中路由加上指定的  URI 前缀，例如，我们可以给路由群组中所有的 URIs 加上路由前缀 `admin` :

    Route::group(['prefix' => 'admin'], function () {
        Route::get('users', function ()    {
            // Matches The "/admin/users" URL
        });
    });

<a name="route-model-binding"></a>
## 路由模型绑定

当注入模型 ID 到路由控制器时，我们通常需要查询这个 ID 的模型，Laravel 路由模型绑定提供了一个方便的方法自动将模型注入到我们的路由中，例如，除了注入一个用户的 ID，你也可以注入与指定 ID 相符的完整 `User` 类实例。

<a name="implicit-binding"></a>
### 隐式绑定

Laravel 会自动解析定义在路由或控制器动作（变量名匹配路由片段）中的 Eloquent 模型类型声明，例如：

    Route::get('api/users/{user}', function (App\User $user) {
        return $user->email;
    });

 在这个例子中，由于类型声明了 Eloquent 模型 `App\User`，对应的变量名 `$user` 会匹配路由片段中的 `{user}`，这样，Laravel 会自动注入与请求 URI 中传入的 ID 对应的用户模型实例。

如果数据库中找不到对应的模型实例，会会自动生成 HTTP 404 响应。

#### 自定义键名

如果你想要隐式模型绑定除 `id` 以为的数据库字段，你可以重写 Eloquent 模型类的 `getRouteKeyName` 方法：

    /**
     * Get the route key for the model.
     *
     * @return string
     */
    public function getRouteKeyName()
    {
        return 'slug';
    }

<a name="explicit-binding"></a>
### 显式绑定

要注册显式绑定，需要使用路由的 model 方法来为给定参数指定绑定类。应该在 RouteServiceProvider::boot 方法中定义模型绑定：

#### 绑定参数至模型
    public function boot()
    {
        parent::boot();

        Route::model('user', 'App\User');
    }

接着，定义包含 `{user}` 参数的路由

    $router->get('profile/{user}', function(App\User $user) {
        //
    });

因为我们已经绑定 `{user}` 参数至 `App\User` 模型，所以 `User` 实例会被注入至该路由。所以，举个例子，一个至 `profile/1` 的请求会注入 ID 为 1 的 `User` 实例。

> **注意：**如果符合的模型不存在于数据库中，就会自动抛出一个 404 异常。

#### 自定义解析逻辑

如果你想要使用自定义的解析逻辑，需要使用 `Route::bind` 方法，传递到 `bind` 方法的闭包会获取到 URI 请求参数中的值，并且返回你想要在该路由中注入的类实例：

    $router->bind('user', function ($value) {
        return App\User::where('name', $value)->first();
    });

<a name="form-method-spoofing"></a>
## 表单方法伪造

HTML 表单没有支持 `PUT`、`PATCH` 或 `DELETE` 动作。所以在从 HTML 表单中调用被定义的 `PUT`、`PATCH` 或 `DELETE` 路由时，你将需要在表单中增加隐藏的 `_method` 字段。跟随 `_method` 字段送出的值将被作为 HTTP 的请求方法使用：

    <form action="/foo/bar" method="POST">
        <input type="hidden" name="_method" value="PUT">
        <input type="hidden" name="_token" value="{{ csrf_token() }}">
    </form>

你也可以使用 `methid_field` 辅助函数来生成隐藏的输入字段 `_method`：

    {{ method_field('PUT') }}

<a name="accessing-the-current-route"></a>
##  获取当前路由信息

你可以使用 `Route` 上的 `current`, `currentRouteName`, and `currentRouteAction` 方法来访问处理当前输入请求的路由信息：

    $route = Route::current();

    $name = Route::currentRouteName();

    $action = Route::currentRouteAction();

更多 API 请参考 [underlying class of the Route facade](http://laravel.com/api/{{version}}/Illuminate/Routing/Router.html) and [Route instance](http://laravel.com/api/{{version}}/Illuminate/Routing/Route.html) 两个文件
